### PR TITLE
fix trimming of /usr/share files

### DIFF
--- a/cbake.psm1
+++ b/cbake.psm1
@@ -86,10 +86,6 @@ function Remove-CBakeExcludedFiles() {
         $ExcludeDir = Join-Path $ExportPath $_
         Remove-Item -Path $ExcludeDir -Recurse -Force -ErrorAction 'SilentlyContinue' | Out-Null
     }
-
-    Get-ChildItem -Path "/usr/share" -Exclude "pkgconfig" | ForEach-Object {
-        Remove-Item $_.FullName -Force -Recurse -ErrorAction 'SilentlyContinue' | Out-Null
-    }
 }
 
 function Optimize-CBakeSysroot() {


### PR DESCRIPTION
trimming of /usr/share just causes too many issues, let's leave it as-is and take the extra size hit.