### PR TITLE
don't cache python bytecode with deb

### DIFF
--- a/recipes/ubuntu-18.04/Dockerfile
+++ b/recipes/ubuntu-18.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/archive.ubuntu.com/ubuntu.mirrors.ovh.net/g' /etc/apt/sources.list

--- a/recipes/ubuntu-20.04/Dockerfile
+++ b/recipes/ubuntu-20.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/archive.ubuntu.com/ubuntu.mirrors.ovh.net/g' /etc/apt/sources.list

--- a/recipes/ubuntu-22.04/Dockerfile
+++ b/recipes/ubuntu-22.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/archive.ubuntu.com/ubuntu.mirrors.ovh.net/g' /etc/apt/sources.list

--- a/recipes/ubuntu-24.04/Dockerfile
+++ b/recipes/ubuntu-24.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/archive.ubuntu.com/ubuntu.mirrors.ovh.net/g' /etc/apt/sources.list


### PR DESCRIPTION
It seems unavoidable to generate python bytecode (py3compile) when installing packages; but the cached .pyc files are not needed in the sysroot so we can prevent them being written to disk.

I hope that this will improve reliability of CI for [conan-public](https://github.com/Devolutions/conan-public), however there should be no negative side effects at least.