### PR TITLE
Fix sysroot recipe builds

### DIFF
--- a/cbake.psm1
+++ b/cbake.psm1
@@ -18,14 +18,22 @@ function Convert-CBakeSymbolicLinks() {
         $Target = Join-Path $RootPath $_.LinkTarget.TrimStart('/')
         if (Test-Path -LiteralPath $Target) {
             $RelativeTarget = [IO.Path]::GetRelativePath($Directory, $Target)
-            Remove-Item -LiteralPath $Source | Out-Null
+            if ($IsLinux) {
+                Invoke-CBakeNativeCommand -FilePath 'rm' -ArgumentList @('-f', '--', $Source)
+            } else {
+                Remove-Item -LiteralPath $Source | Out-Null
+            }
             if ($IsDirectory) {
                 [IO.Directory]::CreateSymbolicLink($Source, $RelativeTarget) | Out-Null
             } else {
                 [IO.File]::CreateSymbolicLink($Source, $RelativeTarget) | Out-Null
             }
         } else {
-            Remove-Item -LiteralPath $Source -ErrorAction 'SilentlyContinue' | Out-Null
+            if ($IsLinux) {
+                Invoke-CBakeNativeCommand -FilePath 'rm' -ArgumentList @('-f', '--', $Source)
+            } else {
+                Remove-Item -LiteralPath $Source -ErrorAction 'SilentlyContinue' | Out-Null
+            }
         }
     }
 }

--- a/cbake.psm1
+++ b/cbake.psm1
@@ -106,6 +106,9 @@ function Remove-CBakeExcludedFiles() {
 
     $ExcludeDirs | ForEach-Object {
         $ExcludeDir = Join-Path $RootPath $_.TrimStart('/', '\')
+        if ($IsLinux -and (Test-Path -LiteralPath $ExcludeDir)) {
+            Invoke-CBakeNativeCommand -FilePath 'chmod' -ArgumentList @('-R', 'u+w', '--', $ExcludeDir)
+        }
         Remove-Item -LiteralPath $ExcludeDir -Recurse -Force -ErrorAction 'SilentlyContinue' | Out-Null
     }
 }
@@ -116,6 +119,10 @@ function Optimize-CBakeSysroot() {
         [Parameter(Mandatory = $true, Position = 0)]
         [string] $RootPath
     )
+
+    if ($IsLinux) {
+        Invoke-CBakeNativeCommand -FilePath 'chmod' -ArgumentList @('-R', 'u+w', '--', $RootPath)
+    }
 
     Convert-CBakeSymbolicLinks $RootPath
     Remove-CBakeExcludedFiles $RootPath

--- a/recipes/debian-10/Dockerfile
+++ b/recipes/debian-10/Dockerfile
@@ -2,8 +2,11 @@ FROM debian:buster-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN sed -i 's/deb.debian.com/debian.mirrors.ovh.net/g' /etc/apt/sources.list
-RUN apt-get update -y
+RUN printf '%s\n' \
+    'deb http://archive.debian.org/debian buster main' \
+    'deb http://archive.debian.org/debian-security buster/updates main' \
+    > /etc/apt/sources.list
+RUN apt-get -o Acquire::Check-Valid-Until=false update -y
 
 RUN apt-get install --no-install-recommends -y \
     gcc \

--- a/recipes/rhel8/Dockerfile
+++ b/recipes/rhel8/Dockerfile
@@ -4,7 +4,7 @@ RUN yum update -y
 
 RUN yum install -y \
     gcc \
-    g++ \
+    gcc-c++ \
     zlib-devel \
     openssl-devel \
     pam \

--- a/tests/CBake.Tests.ps1
+++ b/tests/CBake.Tests.ps1
@@ -71,6 +71,19 @@ Describe 'Convert-CBakeSymbolicLinks' {
         $Link.LinkTarget | Should -Be 'target'
         $Link.ResolveLinkTarget($true).FullName | Should -Be $TargetPath
     }
+
+    It 'converts symlinks from a read-only sysroot on Linux' -Skip:(-not $IsLinux) {
+        $RootPath = Join-Path $TestDrive 'sysroot'
+        $TargetPath = Join-Path $RootPath 'target'
+        $SourcePath = Join-Path $RootPath 'link'
+        New-Item -Path $TargetPath -ItemType Directory -Force | Out-Null
+        [IO.Directory]::CreateSymbolicLink($SourcePath, '/target') | Out-Null
+        & chmod 'a-w' $RootPath
+
+        Optimize-CBakeSysroot $RootPath
+
+        (Get-Item -LiteralPath $SourcePath).LinkTarget | Should -Be 'target'
+    }
 }
 
 Describe 'Remove-CBakeExcludedFiles' {

--- a/tests/CBake.Tests.ps1
+++ b/tests/CBake.Tests.ps1
@@ -96,6 +96,19 @@ Describe 'Remove-CBakeExcludedFiles' {
 
         Test-Path -LiteralPath $ExcludedPath | Should -BeFalse
     }
+
+    It 'removes read-only excluded directories on Linux' -Skip:(-not $IsLinux) {
+        $RootPath = Join-Path $TestDrive 'sysroot'
+        $ExcludedPath = Join-Path $RootPath 'usr\bin'
+        $ExcludedFile = Join-Path $ExcludedPath 'tool'
+        New-Item -Path $ExcludedPath -ItemType Directory -Force | Out-Null
+        New-Item -Path $ExcludedFile -ItemType File -Force | Out-Null
+        & chmod 'a-w' $ExcludedPath
+
+        Remove-CBakeExcludedFiles $RootPath
+
+        Test-Path -LiteralPath $ExcludedPath | Should -BeFalse
+    }
 }
 
 Describe 'Invoke-CBakeNativeCommand' {


### PR DESCRIPTION
## Summary
- restore Debian 10 package access through the Debian archive
- use the correct UBI 8 C++ package name
- handle read-only Linux sysroot directories and symlinks during cleanup

## Validation
- `Invoke-Pester -Path .\tests -CI`
- [cbake sysroots workflow](https://github.com/Devolutions/CBake/actions/runs/30093815768): 24/24 jobs passed