### PR TITLE
Add Ubuntu 22.04 ARM glibc sysroot

### DIFF
--- a/.github/workflows/cbake-sysroots.yml
+++ b/.github/workflows/cbake-sysroots.yml
@@ -13,6 +13,8 @@ jobs:
         include:
           - distro: ubuntu-18.04
             arch: arm
+          - distro: ubuntu-22.04
+            arch: arm
           - distro: alpine-3.17
             arch: arm
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ The GitHub Actions matrix builds every recipe for `amd64` and `arm64`. It also b
 | Compatibility baseline | Archive | Imported sysroot | GCC and Clang target | GCC target directory |
 | --- | --- | --- | --- | --- |
 | Ubuntu 18.04 (glibc) | `ubuntu-18.04-arm-sysroot.tar.xz` | `sysroots\ubuntu-18.04-arm` | `arm-linux-gnueabihf` | `usr\lib\gcc\arm-linux-gnueabihf\<gcc-version>` |
+| Ubuntu 22.04 (glibc 2.35, time64) | `ubuntu-22.04-arm-sysroot.tar.xz` | `sysroots\ubuntu-22.04-arm` | `arm-linux-gnueabihf` | `usr\lib\gcc\arm-linux-gnueabihf\<gcc-version>` |
 | Alpine 3.17 (musl) | `alpine-3.17-arm-sysroot.tar.xz` | `sysroots\alpine-3.17-arm` | `armv7-alpine-linux-musleabihf` | `usr\lib\gcc\armv7-alpine-linux-musleabihf\<gcc-version>` |
 
-Import either archive with `Import-CBakeSysroot -Distro '<distro-version>' -Arch 'arm'`. Set `SYSROOT_NAME` to the imported directory name (for example, `ubuntu-18.04-arm`). The Linux toolchain finds the target triple from its `usr\lib\gcc\<target>\<gcc-version>` layout and applies `-march=armv7-a` for this architecture.
+Import any ARMv7 archive with `Import-CBakeSysroot -Distro '<distro-version>' -Arch 'arm'`. Set `SYSROOT_NAME` to the imported directory name (for example, `ubuntu-22.04-arm`). The Linux toolchain finds the target triple from its `usr\lib\gcc\<target>\<gcc-version>` layout and applies `-march=armv7-a` for this architecture.
 
 To add a distribution, create a new directory under `recipes\` with a Dockerfile and update the workflow matrix if CI should build it.
 

--- a/tests/CBake.Tests.ps1
+++ b/tests/CBake.Tests.ps1
@@ -166,12 +166,12 @@ Describe 'Import-CBakeSysroot' {
         }
     }
 
-    It 'uses the ARMv7 compatibility-baseline archive name' {
-        $PackageFile = Join-Path $script:PackagesPath 'alpine-3.17-arm-sysroot.tar.xz'
+    It 'uses the Ubuntu 22.04 ARMv7 archive name' {
+        $PackageFile = Join-Path $script:PackagesPath 'ubuntu-22.04-arm-sysroot.tar.xz'
         New-Item -Path $PackageFile -ItemType File -Force | Out-Null
         Mock -ModuleName cbake Invoke-CBakeNativeCommand {}
 
-        Import-CBakeSysroot -Distro 'alpine-3.17' -Arch 'arm'
+        Import-CBakeSysroot -Distro 'ubuntu-22.04' -Arch 'arm'
 
         Should -Invoke -CommandName Invoke-CBakeNativeCommand -ModuleName cbake -Exactly -Times 1 -ParameterFilter {
             $FilePath -eq 'tar' -and
@@ -187,6 +187,7 @@ Describe 'New-CBakeSysroot' {
         $script:PackagesPath = Join-Path $TestDrive 'packages'
         New-Item -Path (Join-Path $script:RecipesPath 'ubuntu-24.04') -ItemType Directory -Force | Out-Null
         New-Item -Path (Join-Path $script:RecipesPath 'ubuntu-18.04') -ItemType Directory -Force | Out-Null
+        New-Item -Path (Join-Path $script:RecipesPath 'ubuntu-22.04') -ItemType Directory -Force | Out-Null
         New-Item -Path $script:PackagesPath -ItemType Directory -Force | Out-Null
 
         $Env:CBAKE_RECIPES_DIR = $script:RecipesPath
@@ -219,23 +220,24 @@ Describe 'New-CBakeSysroot' {
         Should -Invoke -CommandName Optimize-CBakeSysroot -ModuleName cbake -Exactly -Times 1
     }
 
-    It 'maps the ARM compatibility label to the ARMv7 Docker platform' {
-        $PackageFile = Join-Path $script:PackagesPath 'ubuntu-18.04-arm-sysroot.tar.xz'
+    It 'normalizes and packages Ubuntu 22.04 ARMv7 output with the stable ARM label' {
+        $PackageFile = Join-Path $script:PackagesPath 'ubuntu-22.04-arm-sysroot.tar.xz'
         Mock -ModuleName cbake Invoke-CBakeNativeCommand {}
         Mock -ModuleName cbake Optimize-CBakeSysroot {}
 
-        New-CBakeSysroot -Distro 'ubuntu-18.04' -Arch 'arm'
+        New-CBakeSysroot -Distro 'ubuntu-22.04' -Arch 'arm'
 
         Should -Invoke -CommandName Invoke-CBakeNativeCommand -ModuleName cbake -Exactly -Times 1 -ParameterFilter {
             $FilePath -eq 'docker' -and
                 $ArgumentList -contains 'linux/arm/v7' -and
-                $ArgumentList -contains 'type=tar,dest=ubuntu-18.04-arm.tar'
+                $ArgumentList -contains 'type=tar,dest=ubuntu-22.04-arm.tar'
         }
         Should -Invoke -CommandName Invoke-CBakeNativeCommand -ModuleName cbake -Exactly -Times 1 -ParameterFilter {
             $FilePath -eq 'tar' -and
                 $ArgumentList[0] -eq 'cfJ' -and
                 $ArgumentList[1] -eq $PackageFile
         }
+        Should -Invoke -CommandName Optimize-CBakeSysroot -ModuleName cbake -Exactly -Times 1
     }
 
     It 'restores the caller location when a checked native command fails' {
@@ -264,6 +266,10 @@ Describe 'Linux ARMv7 toolchains' {
     It 'derives the ARMv7 target from the <SysrootName> GCC layout' -TestCases @(
         @{
             SysrootName = 'ubuntu-18.04-arm'
+            Target = 'arm-linux-gnueabihf'
+        },
+        @{
+            SysrootName = 'ubuntu-22.04-arm'
             Target = 'arm-linux-gnueabihf'
         },
         @{
@@ -303,6 +309,16 @@ endif()
 
         & cmake -P $CMakeScriptPath | Out-Null
         $LASTEXITCODE | Should -Be 0
+    }
+}
+
+Describe 'Sysroot build workflow' {
+    It 'builds the Ubuntu 22.04 ARMv7 archive in the normal matrix' {
+        $WorkflowPath = Join-Path $script:RepoRoot '.github\workflows\cbake-sysroots.yml'
+        $Workflow = Get-Content -Path $WorkflowPath -Raw
+
+        $Workflow | Should -Match '(?ms)- distro: ubuntu-22\.04\s+arch: arm'
+        $Workflow | Should -Match 'packages/\$\{\{matrix\.distro\}\}-\$\{\{matrix\.arch\}\}-sysroot\.tar\.xz'
     }
 }
 }


### PR DESCRIPTION
## Summary

- publish `ubuntu-22.04-arm-sysroot.tar.xz` from the standard ARMv7 sysroot matrix using Docker buildx `linux/arm/v7`
- document the imported `sysroots\ubuntu-22.04-arm` layout and `arm-linux-gnueabihf` GCC target
- cover the stable `arm` label, package naming, archive layout, sysroot normalization path, Docker platform, CMake target discovery, and workflow inclusion with Pester

Ubuntu 22.04 supplies glibc 2.35, including the ARM time64 entry points required by .NET 9 Native AOT.

## Validation

- `pwsh -NoLogo -NoProfile -Command "Import-Module .\cbake.psm1 -Force; Get-CBakePath"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path .\tests -CI"` (16 passed, 2 skipped)
- `git diff --check`

A local Docker build was not run because the Docker Desktop Linux daemon is unavailable in this environment; CI will execute the buildx workflow.